### PR TITLE
Add a failing feature test for wrapping non-tail object-literal args

### DIFF
--- a/test/features/invocation_object_literal_first.coffee
+++ b/test/features/invocation_object_literal_first.coffee
@@ -1,0 +1,1 @@
+test {url: url}, options or {}

--- a/test/features/invocation_object_literal_first.js
+++ b/test/features/invocation_object_literal_first.js
@@ -1,0 +1,1 @@
+test({url: url}, options || {});


### PR DESCRIPTION
I found this and simplified it a bit when attempting to convert a large JavaScript file.
