### PR TITLE
Fix cake test

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -2,7 +2,7 @@
 
 # Tasks
 task 'test', 'Run tests', ->
-  require 'test/test'
+  require __dirname + '/test/test'
 
 task 'build', 'Builds the browser version', ->
   {readFileSync, writeFileSync} = require('fs')


### PR DESCRIPTION
`cake test` is broken.

```
$ cake test
Error: Cannot find module 'test/test'
    at Function._resolveFilename (module.js:334:11)
    at Function._load (module.js:279:25)
    at Module.require (module.js:357:17)
    at require (module.js:368:17)
```

I fixed this issue using absolute path.
