### PR TITLE
Exit when compile completed

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -43,3 +43,4 @@ module.exports =
       throw e  unless e.constructor in [UnsupportedError, SyntaxError]
       console.warn "Error: #{e.message}"
       console.warn "Cursor position: #{e.cursor}"
+      process.exit 1


### PR DESCRIPTION
Using Node.js 0.6.x, process don't exit at compile completed.
