### PR TITLE
Added the ability to output more Pythonic code by providing --pythonic

### DIFF
--- a/lib/codestyle.coffee
+++ b/lib/codestyle.coffee
@@ -1,0 +1,53 @@
+# Number of spaces to use for each step of indent
+tabspacing = 2
+
+# Should function calls be parenthesized?
+#   when set to false:
+#       aMethodCall "value"
+#    when set to true:
+#       aMethodCall("value")
+parenthesized_calls = false
+
+# Should we use an explicit return?
+#   when set to false:
+#       fn = ->
+#         "value"
+#    when set to true:
+#       fn = ->
+#         return "value"
+explicit_return = false
+
+# Should we use unless?
+#   when set to false:
+#       fn = (val) ->
+#         return true if val isnt 'value'
+#    when set to true:
+#       fn = (val) ->
+#         return true unless val is 'value'
+use_unless = true
+
+# Should double space be used in inline statements?
+#   when set to false:
+#       fn = (val) ->
+#         return unless val "value"
+#    when set to true:
+#       fn = (val) ->
+#         return  unless val "value"
+doublespacing_if = true
+
+usePythonic = ->
+  module.exports.tabspacing = 4
+  module.exports.parenthesized_calls = true
+  module.exports.explicit_return = true
+  module.exports.use_unless = false
+  module.exports.doublespacing_if = false
+
+@codestyle = exports = {
+  tabspacing
+  usePythonic
+  explicit_return
+  use_unless
+  doublespacing_if
+}
+
+module.exports = exports  if module?

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -1,4 +1,5 @@
 js2coffee = require('./js2coffee')
+codestyle = require('./codestyle')
 _    = require('underscore')
 fs   = require('fs')
 path = require('path')
@@ -10,6 +11,7 @@ basename = path.basename
 cmd      = basename(process.argv[1])
 
 build_and_show = (fname) ->
+  return if fname == '--pythonic'
   contents = fs.readFileSync(fname, 'utf-8')
   output   = js2coffee.build(contents)
   console.log "%s", output
@@ -23,6 +25,7 @@ runFiles = (proc) ->
     if files.length == 0
       console.warn "Usage:"
       console.warn "  #{cmd} file.js"
+      console.warn "  #{cmd} --pythonic file.js (will output more Pythonic code)"
       console.warn "  #{cmd} file.js > output.txt"
       console.warn "  cat file.js | #{cmd}"
       process.exit 1
@@ -36,6 +39,10 @@ runFiles = (proc) ->
 module.exports =
   run: (args...) ->
     try
+      #Determine if a Pythonic style should be used
+      if (''+process.argv).indexOf('--pythonic') isnt -1
+        codestyle.usePythonic()
+
       runFiles.apply this, args
 
     catch e

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,18 +1,21 @@
 # ## Code snippet helper
 # A helper class to deal with building code.
 
+codestyle = @codestyle or require('./codestyle')
 CoffeeScript = @CoffeeScript or require 'coffee-script'
 
 class Code
   constructor: ->
     @code = ''
+    tabspacing = codestyle.tabspacing
+    @tab_space = ('' for i in [0..tabspacing]).join(' ')
 
   add: (str) ->
     @code += str.toString()
     @
 
   scope: (str, level=1) ->
-    indent = strRepeat("  ", level)
+    indent = strRepeat(@tab_space, level)
     @code  = rtrim(@code) + "\n"
     @code += indent + rtrim(str).replace(/\n/g, "\n#{indent}") + "\n"
     @
@@ -23,7 +26,7 @@ class Code
 # ## String helpers
 # These are functions that deal with strings.
 
-# `paren()`  
+# `paren()`
 # Wraps a given string in parentheses.
 # Examples:
 #
@@ -37,7 +40,7 @@ paren = (string) ->
     else
       "(#{str})"
 
-# `strRepeat()`  
+# `strRepeat()`
 # Repeats a string a certain number of times.
 # Example:
 #
@@ -46,7 +49,7 @@ paren = (string) ->
 strRepeat = (str, times) ->
     (str for i in [0...times]).join('')
 
-# `trim()` *and friends*  
+# `trim()` *and friends*
 # String trimming functions.
 
 ltrim = (str) ->
@@ -64,7 +67,7 @@ trim = (str) ->
 isSingleLine = (str) ->
   trim(str).indexOf("\n") == -1
 
-# `unshift()`  
+# `unshift()`
 # Removes any unneccesary indentation from a code block string.
 unshift = (str) ->
   str = "#{str}"
@@ -76,7 +79,7 @@ unshift = (str) ->
     return str  if !m1 or !m2 or m1.length != m2.length
     str = str.replace(/^ /gm, '')
 
-# `strEscape()`  
+# `strEscape()`
 # Escapes a string.
 # Example:
 #
@@ -85,7 +88,7 @@ unshift = (str) ->
 strEscape = (str) ->
   JSON.stringify "#{str}"
 
-# `p()`  
+# `p()`
 # Debugging tool. Prints an object to the console.
 # Not actually used, but here for convenience.
 p = (str) ->
@@ -100,7 +103,7 @@ p = (str) ->
 # for use by `unreserve()`
 coffeescript_reserved = ( word for word in CoffeeScript.RESERVED when word != 'undefined' )
 
-# `unreserve()`  
+# `unreserve()`
 # Picks the next best thing for a reserved keyword.
 # Example:
 #

--- a/lib/js2coffee.coffee
+++ b/lib/js2coffee.coffee
@@ -735,7 +735,7 @@ class Transformer
 
   'if': (n) ->
     # *Account for `if(x) {} else { something }` which should be `something unless x`.*
-    if n.thenPart.children.length == 0 and n.elsePart?.children.length > 0
+    if n.thenPart.src() is '{' and n.thenPart.children.length == 0 and n.elsePart?.children.length > 0
       n.positive = false
       n.thenPart = n.elsePart
       delete n.elsePart

--- a/lib/js2coffee.coffee
+++ b/lib/js2coffee.coffee
@@ -24,6 +24,9 @@ unshift, isSingleLine,
 trim, blockTrim, ltrim,
 rtrim, strRepeat, paren} = @Js2coffeeHelpers or require('./helpers')
 
+codestyle = @codestyle or require('./codestyle')
+
+
 # ## Main entry point
 # This is `require('js2coffee').build()`. It takes a JavaScript source
 # string as an argument, and it returns the CoffeeScript version.
@@ -51,7 +54,7 @@ class Builder
   constructor: ->
     @transformer = new Transformer
 
-  # `build()`  
+  # `build()`
   # The main entry point.
 
   # This finds the appropriate @builder function for `node` based on it's type,
@@ -72,7 +75,7 @@ class Builder
 
     if node.parenthesized then paren(out) else out
 
-  # `transform()`  
+  # `transform()`
   # Perform a transformation on the node, if a transformation function is
   # available.
 
@@ -82,12 +85,12 @@ class Builder
   # `body()`
   # Works like `@build()`, and is used for code blocks. It cleans up the returned
   # code block by removing any extraneous spaces and such.
-  
+
   body: (node, opts={}) ->
     str = @build(node, opts)
     str = blockTrim(str)
     str = unshift(str)
-  
+
     if str.length > 0 then str else ""
 
   # ## The builders
@@ -97,7 +100,7 @@ class Builder
   #
   # These are invoked using the main entry point, `Builder#build()`.
 
-  # `script`  
+  # `script`
   # This is the main entry point.
 
   'script': (n, opts={}) ->
@@ -109,7 +112,7 @@ class Builder
 
     c.toString()
 
-  # `property_identifier`  
+  # `property_identifier`
   # A key in an object literal.
 
   'property_identifier': (n) ->
@@ -124,7 +127,7 @@ class Builder
     else
       strEscape str
 
-  # `identifier`  
+  # `identifier`
   # Any object identifier like a variable name.
 
   'identifier': (n) ->
@@ -144,7 +147,7 @@ class Builder
     else
       unreserve n
 
-  # `id_param`  
+  # `id_param`
   # Function parameters. Belongs to `list`.
 
   'id_param': (n) ->
@@ -153,7 +156,7 @@ class Builder
     else
       @id n
 
-  # `return`  
+  # `return`
   # A return statement. Has `n.value` of type `id`.
 
   'return': (n) ->
@@ -163,7 +166,7 @@ class Builder
     else
       "return #{@build(n.value)}\n"
 
-  # `;` (aka, statement)  
+  # `;` (aka, statement)
   # A single statement.
 
   ';': (n) ->
@@ -184,7 +187,7 @@ class Builder
     else
       @build(n.expression) + "\n"
 
-  # `new` + `new_with_args`  
+  # `new` + `new_with_args`
   # For `new X` and `new X(y)` respctively.
 
   'new': (n) -> "new #{@build n.left()}"
@@ -289,7 +292,7 @@ class Builder
     else
       "#{sign}#{@build n.left()}"
 
-  # `=` (aka, assignment)  
+  # `=` (aka, assignment)
   # For `a = b` (but not `var a = b`: that's `var`).
 
   '=': (n) ->
@@ -300,14 +303,14 @@ class Builder
 
     "#{@build n.left()} #{sign} #{@build n.right()}"
 
-  # `,` (aka, comma)  
+  # `,` (aka, comma)
   # For `a = 1, b = 2'
 
   ',': (n) ->
     list = _.map n.children, (item) => @build(item) + "\n"
     list.join('')
 
-  # `regexp`  
+  # `regexp`
   # Regular expressions.
 
   'regexp': (n) ->
@@ -332,7 +335,7 @@ class Builder
   'string': (n) ->
     strEscape n.value
 
-  # `call`  
+  # `call`
   # A Function call.
   # `n.left` is an `id`, and `n.right` is a `list`.
 
@@ -342,7 +345,7 @@ class Builder
     else
       "#{@build n.left()}(#{@build n.right()})"
 
-  # `call_statement`  
+  # `call_statement`
   # A `call` that's on it's own line.
 
   'call_statement': (n) ->
@@ -358,9 +361,12 @@ class Builder
     if n.right().children.length == 0
       "#{left}()"
     else
-      "#{left} #{@build n.right()}"
+      if codestyle.parenthesized_calls
+        "#{left}(#{@build n.right()})"
+      else
+        "#{left} #{@build n.right()}"
 
-  # `list`  
+  # `list`
   # A parameter list.
 
   'list': (n) ->
@@ -376,7 +382,7 @@ class Builder
     ids = ids.join(', ')
     "delete #{ids}\n"
 
-  # `.` (scope resolution?)  
+  # `.` (scope resolution?)
   # For instances such as `object.value`.
 
   '.': (n) ->
@@ -430,7 +436,7 @@ class Builder
     c.scope @body(n.block)
     c
 
-  # `?` (ternary operator)  
+  # `?` (ternary operator)
   # For `a ? b : c`. Note that these will always be parenthesized, as (I
   # believe) the order of operations in JS is different in CS.
 
@@ -484,21 +490,25 @@ class Builder
   'if': (n) ->
     c = new Code
 
-    keyword = if n.positive then "if" else "unless"
+    if codestyle.use_unless is false
+      keyword = if n.positive then "if " else "if "
+    else if codestyle.doublespacing_if
+      keyword = if n.positive then " if " else " unless "
+    else
+      keyword = if n.positive then "if " else "unless "
     body_   = @body(n.thenPart)
     n.condition.parenthesized = false
 
     # *Account for `if (xyz) {}`, which should be `xyz`. (#78)*
     # *Note that `!xyz` still compiles to `xyz` because the `!` will not change anything.*
     if n.thenPart.isA('block') and n.thenPart.children.length == 0 and !n.elsePart?
-      console.log n.thenPart
       c.add "#{@build n.condition}\n"
 
     else if isSingleLine(body_) and !n.elsePart?
-      c.add "#{trim body_}  #{keyword} #{@build n.condition}\n"
+      c.add "#{trim body_} #{keyword}#{@build n.condition}\n"
 
     else
-      c.add "#{keyword} #{@build n.condition}"
+      c.add "#{keyword}#{@build n.condition}"
       c.scope @body(n.thenPart)
 
       if n.elsePart?
@@ -524,7 +534,7 @@ class Builder
           c.add ", #{@build item.caseLabel}\n"
         else
           c.add "  when #{@build item.caseLabel}"
-          
+
       if @body(item.statements).length == 0
         fall_through = true
       else
@@ -545,7 +555,7 @@ class Builder
     else
       "[ #{@list n} ]"
 
-  # `property_init`  
+  # `property_init`
   # Belongs to `object_init`;
   # left is a `identifier`, right can be anything.
 
@@ -555,7 +565,7 @@ class Builder
     right.is_property_value = true
     "#{@property_identifier left}: #{@build right}"
 
-  # `object_init`  
+  # `object_init`
   # An object initializer.
   # Has many `property_init`.
 
@@ -574,7 +584,7 @@ class Builder
       c = "{#{c}}"  if options.brackets?
       c
 
-  # `function`  
+  # `function`
   # A function. Can be an anonymous function (`function () { .. }`), or a named
   # function (`function name() { .. }`).
 
@@ -626,7 +636,7 @@ class Builder
   'block': (args...) ->
     @script.apply @, args
 
-  # `unsupported()`  
+  # `unsupported()`
   # Throws an unsupported error.
   'unsupported': (node, message) ->
     throw new UnsupportedError("Unsupported: #{message}", node)
@@ -696,7 +706,8 @@ class Transformer
         else
           parent.children[parent.children.length-1]
 
-        if lastNode
+        #XXX: Look at omitting this
+        if lastNode and not codestyle.explicit_return
           lastNode.type = Typenames[';']
           lastNode.expression = lastNode.value
 
@@ -745,13 +756,21 @@ class Transformer
 
     # *Invert a '!='. (`if (x != y)` => `unless x is y`)*
     if n.condition.isA('!=')
-      n.condition.type = Typenames['==']
-      n.positive = not positive
+      if codestyle.use_unless
+        n.condition.type = Typenames['==']
+        n.positive = not positive
+      else
+        n.condition.type = Typenames['!=']
+        n.positive = false
 
     # *Invert a '!'. (`if (!x)` => `unless x`)*
     else if n.condition.isA('!')
-      n.condition = n.condition.left()
-      n.positive = not positive
+      if codestyle.use_unless
+        n.condition = n.condition.left()
+        n.positive = not positive
+      else
+        n.condition.type = Typenames['!']
+        n.positive = false
 
     else
       n.positive = positive


### PR DESCRIPTION
Made following options configureable via lib/codestyle.coffee:

tabspacing = 2
parenthesized_calls = false
explicit_return = false
use_unless = true
doublespacing_if = true

Added a command line option --pythonic that when provided will
configure code style to be more pythonic (tabspace 4, no unless,
parenthesized calls and explicit returns).

Commandline parsing is a bit dirty now and I would have used something
like commander (npm commander), but I am unsure what the author prefers.




A showcase of the new features:
~/> cat test.'s

    function helloWorld(some_value) {
        if(some_value != 'hello')
            return;
        aFunctionCall('hello');
        return "value";
    }

~/> ./bin/js2coffee test.js

    helloWorld = (some_value) ->
      return  unless some_value is "hello"
      aFunctionCall "hello"
      "value"

~/> ./bin/js2coffee --pythonic test.js

    helloWorld = (some_value) ->
        return if some_value isnt "hello"
        aFunctionCall("hello")
        return "value"
