### PR TITLE
Fix array translation bug - closes issue #127

### DIFF
--- a/lib/js2coffee.coffee
+++ b/lib/js2coffee.coffee
@@ -547,7 +547,7 @@ class Builder
     if n.children.length == 0
       "[]"
     else
-      "[ #{@list n} ]"
+      "[#{@list n}]"
 
   # `property_init`  
   # Belongs to `object_init`;


### PR DESCRIPTION
fixes translation of arrays extra-space bug, which may cause coffee code to not compile in some circumstances.
