### PR TITLE
Fix global leak

### DIFF
--- a/lib/narcissus_packed.js
+++ b/lib/narcissus_packed.js
@@ -45,16 +45,12 @@ if (typeof module == 'undefined') {
   this.Narcissus = new Object;
 }
 
-(function() {
-
-    var narcissus = {
-        options: {
-            version: 185,
-        },
-        hostGlobal: this
-    };
-    Narcissus = narcissus;
-})();
+var Narcissus = {
+    options: {
+        version: 185,
+    },
+    hostGlobal: this
+};
 
 Narcissus.definitions = (function() {
 


### PR DESCRIPTION
narcissus_packed.js leaks a global Narcissus (which is not needed in order to function properly.  This fixes that global leak.
