### PR TITLE
Remove error in narcissus regarding continue

### DIFF
--- a/lib/narcissus_packed.js
+++ b/lib/narcissus_packed.js
@@ -1322,8 +1322,6 @@ Narcissus.parser = (function() {
 
             if (!n.target)
                 throw t.newSyntaxError("Invalid " + ((tt === BREAK) ? "break" : "continue"));
-            if (!n.target.isLoop && tt === CONTINUE)
-                throw t.newSyntaxError("Invalid continue");
 
             break;
 

--- a/test/features/for_continue.coffee
+++ b/test/features/for_continue.coffee
@@ -1,0 +1,15 @@
+i = 0
+while i < 5
+  continue  if i is 2
+  alert i
+  ++i
+i = 0
+while i < 5
+  switch i
+    when 1
+      alert "one"
+    when 2, 3
+      continue
+    else
+      alert i
+  ++i

--- a/test/features/for_continue.js
+++ b/test/features/for_continue.js
@@ -1,0 +1,20 @@
+for(i = 0; i <5; ++i) {
+	if(i == 2) {
+		continue;
+	}
+	alert(i);
+}
+
+for(i = 0; i <5; ++i) {
+	switch(i) {
+	case 1:
+		alert("one");
+		break;
+	case 2:
+	case 3:
+		continue
+		break;
+	default:
+		alert(i);
+	}
+}


### PR DESCRIPTION
Narcissus only allowed continues to be in a direct loop block, which
made it bark on allowed code.
We remove the whole requirement as it's not needed.
