### PR TITLE
Fixes Cannot read property 'length' of undefined error

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -3,6 +3,9 @@
 
 CoffeeScript = @CoffeeScript or require 'coffee-script'
 
+unless CoffeeScript.RESERVED then CoffeeScript.RESERVED =
+  require('coffee-script/lib/coffee-script/lexer.js').RESERVED
+
 class Code
   constructor: ->
     @code = ''


### PR DESCRIPTION
Newer versions of coffeescript do not expose the RESERVED words array. This fix defines the array if not defined by the loaded coffeescript version.
