### PR TITLE
Update package.json with correct coffee-script version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "underscore": ">= 0.0.1",
-    "coffee-script": ">= 1.1.0",
+    "coffee-script": "= 1.1.0",
     "file": ">= 0.1.0"
   },
   "scripts": {


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/rstacruz/js2coffee/issues/199) versions of coffee-script after 1.1.0 cause an error in this script. Workaround proposed in the issue (setting coffee-script dependency in `package.json` to `= 1.1.0` instead of `>= 1.1.0` solved the issue nicely. 
