### PR TITLE
Handle JS strings that contain CS string interpolations.

### DIFF
--- a/src/documents/lib/helpers.js.coffee
+++ b/src/documents/lib/helpers.js.coffee
@@ -92,7 +92,11 @@ truthy = (n) ->
 #   * `hello "there"` turns to `"hello \"there\""`
 #
 strEscape = (str) ->
-  JSON.stringify "#{str}"
+  str = JSON.stringify "#{str}"
+  # JavaScript doesn't have string interpolation and so may contain strings
+  # that in CoffeeScript would compile as string interpolations,
+  # e.g. "hey #{jude}". We need to escape them here.
+  str.replace /#\{/g, '\\#{'
 
 # `p()`
 # Debugging tool. Prints an object to the console.

--- a/src/documents/test/features/fake_string_interpolation.coffee
+++ b/src/documents/test/features/fake_string_interpolation.coffee
@@ -1,0 +1,1 @@
+handlebars = "\#{{orderNumber}}: receipt \#{{receiptNumber}} cost {{price}}"

--- a/src/documents/test/features/fake_string_interpolation.js
+++ b/src/documents/test/features/fake_string_interpolation.js
@@ -1,0 +1,1 @@
+var handlebars = "#{{orderNumber}}: receipt #{{receiptNumber}} cost {{price}}";


### PR DESCRIPTION
Pulled out separately from #192 at @balupton's request.
