### PR TITLE
Fix `when` indentation error when use tabs

### DIFF
--- a/src/documents/lib/js2coffee.js.coffee
+++ b/src/documents/lib/js2coffee.js.coffee
@@ -665,7 +665,7 @@ class Builder
         if fall_through == true
           c.add @l(item)+", #{@build item.caseLabel}"
         else
-          c.add @l(item)+"  when #{@build item.caseLabel}"
+          c.add @l(item)+"#{Code.INDENT}when #{@build item.caseLabel}"
 
       if @body(item.statements).length == 0
         fall_through = true

--- a/src/documents/test/everything.js.coffee
+++ b/src/documents/test/everything.js.coffee
@@ -20,7 +20,7 @@ joe.suite 'js2coffee', (suite,test) ->
       ###
 
       # default options
-      options = {no_comments: true}
+      options = {no_comments: true, indent: "  "}
       optionsPattern = /^\/\/\s*OPTIONS:\s*(.*)/
       input = fs.readFileSync(f).toString().trim()
       matches = input.match optionsPattern

--- a/src/documents/test/features/switch_indent_tab.coffee
+++ b/src/documents/test/features/switch_indent_tab.coffee
@@ -1,0 +1,12 @@
+switch x
+	when 2
+		a
+	when 3
+		b
+	else
+		x
+switch x
+	when 2, 3
+		b
+	else
+		x

--- a/src/documents/test/features/switch_indent_tab.js
+++ b/src/documents/test/features/switch_indent_tab.js
@@ -1,0 +1,3 @@
+// OPTIONS: {"indent": "\t"}
+switch (x) { case 2: a; break; case 3: b; break; default: x; }
+switch (x) { case 2: case 3: b; break; default: x; }


### PR DESCRIPTION
When use `js2coffee -it` that use tab to indents, the `when` command in `switch` not use tab but use normal spaces. This commit fixed it.

However, after use `// OPTIONS: {"indent": "\t"}` in newly added test file, the other test files run later will fail because indent option is stored and not reset. So I changed default test options to include `indent`.
