### PR TITLE
* [bug] printWarning raise error when warning no start property

### DIFF
--- a/bin/js2coffee
+++ b/bin/js2coffee
@@ -84,10 +84,11 @@ function printWarnings (warnings) {
 
   var comments = warnings.map(function (warn) {
     var msg = '' +
-      warn.filename + ':' +
-      warn.start.line + ':' +
-      warn.start.column + ': ' +
-      c(34, '[warning] ') +
+      warn.filename + ':'+ warn.start.line + ':'
+    if (warn.start)
+      msg += warn.start.line + ':' +
+        warn.start.column + ': '
+    msg += c(34, '[warning] ') +
       warn.description;
 
     console.warn(msg);


### PR DESCRIPTION
js2coffee t.js

```bash
Cannot read property 'line' of undefined
TypeError: Cannot read property 'line' of undefined
    at /usr/local/lib/node_modules/js2coffee/bin/js2coffee:87:39
    at Array.map (native)
    at printWarnings (/usr/local/lib/node_modules/js2coffee/bin/js2coffee:85:27)
```

```js
//t.js
var A = (function() {
    function A() {}
    return A;
  })();
```