### PR TITLE
Use upstream Esprima 2.x.

### DIFF
--- a/js2coffee.coffee
+++ b/js2coffee.coffee
@@ -57,7 +57,7 @@ js2coffee.build = (source, options = {}) ->
 
 js2coffee.parseJS = (source, options = {}) ->
   try
-    Esprima = require('esprima-fb')
+    Esprima = require('esprima')
     Esprima.parse(source, loc: true, range: true, comment: true)
   catch err
     throw buildError(err, source, options.filename)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "escodegen": "^1.6.0",
-    "esprima-fb": "^10001.1.0-dev-harmony-fb",
+    "esprima": "^2.4.0",
     "estraverse": "^1.9.1",
     "minimist": "^1.1.0",
     "read-input": "^0.2.0",

--- a/test/precedence.coffee
+++ b/test/precedence.coffee
@@ -5,7 +5,7 @@ describe 'Precedence', ->
 
   test = (js, level) ->
     it "[#{level}] #{js}", ->
-      node = require('esprima-fb').parse(js).body[0].expression
+      node = require('esprima').parse(js).body[0].expression
       result = getPrecedence(node)
       if result isnt level
         console.log node


### PR DESCRIPTION
Facebook's fork is deprecated. Let's just use the mainline Esprima 2 since it already supports all major ES6 features.