### PR TITLE
Misc bug fixes

### DIFF
--- a/lib/builder/index.coffee
+++ b/lib/builder/index.coffee
@@ -141,7 +141,13 @@ class Builder extends BuilderBase
     @makeStatements(node, node.body)
 
   makeStatements: (node, body) ->
-    prependAll(body.map(@walk), @indent())
+    walked = body.map(@walk)
+    ret = []
+    for item, i in walked
+      if body[i].type isnt "BlockStatement"
+        ret.push @indent()
+      ret.push item
+    ret
 
   LineComment: (node) ->
     [ "#", node.value, "\n" ]

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -188,13 +188,17 @@ exports.clone = (obj) ->
 exports.quote = (str) ->
   if typeof str is 'string'
     # escape quotes
+    format_char_code = (char) ->
+      ret = char.charCodeAt(0).toString(16)
+      ret = ("0" for [0...(4 - ret.length)]).join('') + ret
+      "\\u" + ret
     re = str
       .replace(/\\/g, '\\\\')
       .replace(/'/g, "\\'")
       .replace(/\\"/g, '"')
       .replace(/\n/g, '\\n')
       .replace(/[\u0000-\u0019\u00ad\u200b\u2028\u2029\ufeff]/g,
-        (x) -> "\\u#{x.charCodeAt(0).toString(16)}")
+        format_char_code)
     "'#{re}'"
 
   else

--- a/lib/helpers/index.coffee
+++ b/lib/helpers/index.coffee
@@ -188,13 +188,17 @@ exports.clone = (obj) ->
 exports.quote = (str) ->
   if typeof str is 'string'
     # escape quotes
+    format_char_code = (char) ->
+      ret = char.charCodeAt(0).toString(16)
+      ret = ("0" for [0...(4 - ret.length)]).join('') + ret
+      "\\u" + ret
     re = str
       .replace(/\\/g, '\\\\')
       .replace(/'/g, "\\'")
       .replace(/\\"/g, '"')
       .replace(/\n/g, '\\n')
       .replace(/[\u0000-\u0019\u00ad\u200b\u2028\u2029\ufeff]/g,
-        (x) -> "\\u#{x.charCodeAt(0).toString(16)}")
+        format_char_code)
     "'#{re}'"
 
   else

--- a/lib/transforms/base.coffee
+++ b/lib/transforms/base.coffee
@@ -188,7 +188,7 @@ class TransformerBase
 
   pushStack: (node) ->
     [ oldScope, oldCtx ] = [ @scope, @ctx ]
-    @scopes.push [ node, @ctx ]
+    @scopes.push [ @scope , @ctx ]
     @ctx = clone(@ctx)
     @scope = node
     @onScopeEnter?(@scope, @ctx, oldScope, oldCtx)

--- a/lib/transforms/functions.coffee
+++ b/lib/transforms/functions.coffee
@@ -20,7 +20,7 @@ module.exports = class extends TransformerBase
 
   onScopeExit: (scope, ctx, subscope, subctx) ->
     if subctx.prebody.length
-      @prependIntoBody(scope.body, subctx.prebody)
+      @prependIntoBody(subscope.body, subctx.prebody)
 
   # prepend the functions back into the body.
   # be sure to place them after variable declarations.

--- a/lib/transforms/loops.coffee
+++ b/lib/transforms/loops.coffee
@@ -95,12 +95,15 @@ module.exports = class extends TransformerBase
     else
       'WhileStatement'
 
-    if node.init?
+    i = node.init
+    delete node.init
+
+    if i?
       type: 'BlockStatement'
       body: [
         {
           type: 'ExpressionStatement'
-          expression: node.init
+          expression: i
         }
         node
       ]

--- a/lib/transforms/others.coffee
+++ b/lib/transforms/others.coffee
@@ -15,6 +15,11 @@ module.exports = class extends TransformerBase
     @preventReservedWords(node.id)
     @removeUndefinedParameter(node)
 
+  FunctionExpressionExit: (node) ->
+    super(node)
+    node.body.body.splice(0, 0, (node.body.shadows ? [])...)
+    node
+
   CallExpression: (node) ->
     @parenthesizeCallee(node)
 
@@ -92,7 +97,8 @@ module.exports = class extends TransformerBase
         expression:
           type: 'CoffeeEscapedExpression'
           raw: "var #{name}"
-      @scope.body = [ statement ].concat(@scope.body)
+      @scope.shadows ?= []
+      @scope.shadows.push(statement)
     else
       @ctx.vars.push name
 

--- a/lib/transforms/returns.coffee
+++ b/lib/transforms/returns.coffee
@@ -8,7 +8,7 @@ TransformerBase = require('./base')
 module.exports = class extends TransformerBase
 
   onScopeExit: (scope, ctx, subscope, subctx) ->
-    @unreturnify scope
+    @unreturnify subscope
 
   ###
   # Removes return statements

--- a/test/build.coffee
+++ b/test/build.coffee
@@ -27,3 +27,30 @@ loop
 """
     expect(out).equals(expected)
 
+  it 'inserts var statements into correct scope', ->
+    out = js2coffee """
+var a = 0;
+var foo = function () {
+  var b = function () {
+    return 0;
+  };
+  var a = 1;
+};
+"""
+
+    expected = """
+a = 0
+
+foo = ->
+  `var a`
+
+  b = ->
+    0
+
+  a = 1
+  return
+
+"""
+    expect(out).equals(expected)
+
+

--- a/test/build.coffee
+++ b/test/build.coffee
@@ -7,3 +7,23 @@ describe 'build()', ->
     expect(out.ast).be.an('object')
     expect(out.map).be.an('object')
     expect(out.code).be.a('string')
+
+  it 'indents nested blocks correctly', ->
+    out = js2coffee """
+while (true) {
+  {
+    {
+      var a = 0;
+      var b = 1;
+    }
+  }
+}
+"""
+    expected = """
+loop
+  a = 0
+  b = 1
+
+"""
+    expect(out).equals(expected)
+

--- a/test/build.coffee
+++ b/test/build.coffee
@@ -75,4 +75,7 @@ do ->
 """
     expect(out).equals(expected)
 
-
+  it "outputs correct unicode escape sequences", ->
+    out = js2coffee("\"\\u0010\"\n")
+    expected = "\'\\u0010\'\n"
+    expect(out).equals(expected)

--- a/test/build.coffee
+++ b/test/build.coffee
@@ -8,6 +8,7 @@ describe 'build()', ->
     expect(out.map).be.an('object')
     expect(out.code).be.a('string')
 
+
   it 'indents nested blocks correctly', ->
     out = js2coffee """
 while (true) {
@@ -48,6 +49,27 @@ foo = ->
     0
 
   a = 1
+  return
+
+"""
+
+  it "doesn't drop loop init statements immediately after variable shadowing", ->
+    out = js2coffee("""
+var a, b = 0;
+(function () {
+  var a;
+  for (b = 1;;) {
+  }
+})();
+""")
+    expected = """a = undefined
+b = 0
+do ->
+  `var a`
+  a = undefined
+  b = 1
+  loop
+    continue
   return
 
 """


### PR DESCRIPTION
Some bug fixes with code generation and ast generation.

For the "BlockStatement" commit, my observation is that this is yet another special case of checking for node type "BlockStatement." From what I can tell, this is because the code is structured so that the container nodes are responsible for outputting the indent. If the code was instead structured so that the code that emits statements was responsible for the indent, there would be no special cases and the code would be simpler. Something to think about for the future.