### PR TITLE
Use the single `handler` in a TryStatement.

### DIFF
--- a/lib/builder/index.coffee
+++ b/lib/builder/index.coffee
@@ -273,9 +273,9 @@ class Builder extends BuilderBase
     [ "debugger", "\n" ]
 
   TryStatement: (node) ->
-    # block, guardedHandlers, handlers [], finalizer
+    # block, handler, finalizer
     _try = @indent => [ "try", "\n", @walk(node.block) ]
-    _catch = prependAll(node.handlers.map(@walk), @indent())
+    _catch = @indent (indent) => [ indent, @walk(node.handler) ]
     _finally = if node.finalizer?
       @indent (indent) => [ indent, "finally", "\n", @walk(node.finalizer) ]
     else
@@ -284,7 +284,7 @@ class Builder extends BuilderBase
     [ _try, _catch, _finally ]
 
   CatchClause: (node) ->
-    @indent => [ "catch ", @walk(node.param), "\n", @walk(node.body) ]
+    [ "catch ", @walk(node.param), "\n", @walk(node.body) ]
 
   ThrowStatement: (node) ->
     [ "throw ", @walk(node.argument), "\n" ]

--- a/notes/AST.md
+++ b/notes/AST.md
@@ -123,7 +123,7 @@ Can have its argument missing (eg: `return`).
 A try block. Encompasses all `try`, `catch`, and `finally`.
 
    - `block` : [BlockStatement] (the *try*)
-   - `handlers` : [ [CatchClause], ... ] * (the *catch*)
+   - `handler` : [CatchClause] * (the *catch*)
    - `finalizer` : [BlockStatement] * (the *finally*)
 
 ### CatchClause


### PR DESCRIPTION
`handlers`, an array of `CatchClause`s, is deprecated. There is always exactly one element anyway in that array.

Esprima 2.7 still provides both `handlers` and `handler` for compatibility but soon `handlers` will be gone for good. See https://github.com/jquery/esprima/issues/1030 for the details.