### PR TITLE
Use protocol-relative URLs for better https support

### DIFF
--- a/_data/js.yml
+++ b/_data/js.yml
@@ -1,6 +1,6 @@
 js2coffee:
-  url: http://cdn.rawgit.com/js2coffee/js2coffee/v%s/dist/js2coffee.js
+  url: //cdn.rawgit.com/js2coffee/js2coffee/v%s/dist/js2coffee.js
   version: 2.1.0
 coffeescript:
-  url: http://cdn.rawgit.com/jashkenas/coffeescript/%s/extras/coffee-script.js
+  url: //cdn.rawgit.com/jashkenas/coffeescript/%s/extras/coffee-script.js
   version: 1.9.2

--- a/_includes/announcements.html
+++ b/_includes/announcements.html
@@ -8,7 +8,7 @@
   {{ site.data.announcement.body | markdownify }}
 
   <p class='share-buttons'>
-    <a class='share-button twitter' href='http://twitter.com/share?url=http://js2.coffee/&amp;text=js2coffee 2.0 - javascript to coffeescript compiler, rewritten!' target='_blank'>Tweet</a>
+    <a class='share-button twitter' href='https://twitter.com/share?url=http://js2.coffee/&amp;text=js2coffee 2.0 - javascript to coffeescript compiler, rewritten!' target='_blank'>Tweet</a>
     {% include github-button.html %}
     <!-- <a href="http://news.ycombinator.com/submit" data-url="http://js2.coffee/" class="hn-share-button">Vote on HN</a> -->
     <!-- <script src="//hnbutton.appspot.com/static/hn.min.js" async defer></script> -->
@@ -21,4 +21,3 @@
   <span class='date'>{{ site.data.announcement.date }}</span>
   <span class='expando'></span>
 </button>
-

--- a/_includes/mobile-view.html
+++ b/_includes/mobile-view.html
@@ -1,5 +1,5 @@
 <div class='mobile-view'>
-  <a href='http://github.com/js2coffee/js2coffee' class='js2c-logo'></a>
+  <a href='https://github.com/js2coffee/js2coffee' class='js2c-logo'></a>
   <p>
     A JavaScript to CoffeeScript compiler. Open this site
     in your computer for a demo.
@@ -7,7 +7,7 @@
   <a href='http://js2.coffee' class='faux-addressbar'>
     http://js2.coffee
   </a>
-  <a href='http://npmjs.com/js2coffee' class='code-example'>
+  <a href='https://npmjs.com/js2coffee' class='code-example'>
     npm install -g js2coffee
   </a>
   <p>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 <div class='main-sidebar'>
-  <a href='http://github.com/js2coffee/js2coffee' class='js2c-logo'></a>
-  <a href='http://npmjs.com/js2coffee' class='code-example'>
+  <a href='https://github.com/js2coffee/js2coffee' class='js2c-logo'></a>
+  <a href='https://npmjs.com/js2coffee' class='code-example'>
     npm install -g js2coffee
   </a>
 

--- a/assets/style.sass
+++ b/assets/style.sass
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700')
+@import url('//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700')
 @import 'ionicons'
 
 +ion-font()
@@ -453,7 +453,7 @@ a:hover, a:focus
     div
       opacity: 0.5
 
-.CodeMirror-overlayscroll 
+.CodeMirror-overlayscroll
   .CodeMirror-scrollbar-filler
     background: transparent
 
@@ -843,7 +843,7 @@ a:hover, a:focus
     color: mix($text, $litetext, 50%)
     border-bottom: solid 1px rgba(white, 0.2)
 
-  iframe  
+  iframe
     position: relative
     left: 20px
 

--- a/master.html
+++ b/master.html
@@ -7,8 +7,8 @@
     <title>js2coffee [m]</title>
     <link rel='stylesheet' href='assets/vendor.css'>
     <link rel='stylesheet' href='assets/style.css'>
-    <script src="http://rawgit.com/js2coffee/js2coffee/master/dist/js2coffee.js"></script>
-    <script src='http://cdn.rawgit.com/jashkenas/coffeescript/1.9.0/extras/coffee-script.js'></script>
+    <script src="//rawgit.com/js2coffee/js2coffee/master/dist/js2coffee.js"></script>
+    <script src='//cdn.rawgit.com/jashkenas/coffeescript/1.9.0/extras/coffee-script.js'></script>
     <script src='assets/vendor.js'></script>
     <script src='assets/app.js'></script>
 </head>


### PR DESCRIPTION
Currently, the site can be accessed over https via https://js2coffee.github.io/js2coffee/, but the following mixed-content errors come up:

> Blocked loading mixed active content "http://cdn.rawgit.com/js2coffee/js2coffee/v2.1.0/dist/js2coffee.js"
> Blocked loading mixed active content "http://cdn.rawgit.com/jashkenas/coffeescript/1.9.2/extras/coffee-script.js"
> Blocked loading mixed active content "http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"

This PR fixes those errors by using protocol-relative URLS (// instead of http://)

Also consider using https://js2.coffee via CloudFlare. See here: https://support.cloudflare.com/hc/en-us/articles/203663694-How-do-I-enable-free-Universal-SSL-with-Github-