### PR TITLE
fixes #440: typo: CoffeeScirpt -> CoffeeScript

### DIFF
--- a/lib/transforms/unsupported.coffee
+++ b/lib/transforms/unsupported.coffee
@@ -7,7 +7,7 @@ module.exports = class extends TransformerBase
   ###
 
   LabeledStatement: (node, parent) ->
-    @syntaxError node, "Labeled statements are not supported in CoffeeScirpt"
+    @syntaxError node, "Labeled statements are not supported in CoffeeScript"
 
   WithStatement: (node) ->
     @syntaxError node, "'with' is not supported in CoffeeScript"


### PR DESCRIPTION
Fixes #440.